### PR TITLE
Fix #14 - invalid ASIN array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "name": "marcl/amazonproductapi",
-    "description": "PHP library to perform product lookup and searches using the Amazon Product API.",
-    "version": "3.0.1",
+    "description":
+        "PHP library to perform product lookup and searches using the Amazon Product API.",
+    "version": "3.0.2",
     "type": "library",
     "keywords": ["amazon", "product", "api"],
     "homepage": "https://github.com/MarcL/AmazonProductAPI/",
@@ -31,4 +32,5 @@
             "MarcL\\": "src/",
             "tests\\": "tests/"
         }
-    }}
+    }
+}

--- a/examples.php
+++ b/examples.php
@@ -48,4 +48,13 @@ sleep($sleepTime);
 $items = $amazonAPI->ItemLookUp('B01GAGVIE4', true);
 print('>> Look up specific ASIN\n');
 var_dump($items);
+
+sleep($sleepTime);
+
+// Amazon echo, lookup with incorrect ASIN array
+$asinIds = array('INVALID', 'INVALIDASIN', 'NOTANASIN');
+$items = $amazonAPI->ItemLookUp($asinIds, true);
+print('>> Look up specific ASIN\n');
+var_dump($items);
+var_dump($amazonAPI->GetErrors());
 ?>

--- a/src/AmazonAPI.php
+++ b/src/AmazonAPI.php
@@ -135,15 +135,16 @@ class AmazonAPI
 			$response = $request->execute($signedUrl);
 
 			$parsedXml = simplexml_load_string($response);
+
+			if ($parsedXml === false) {
+				return false;
+			}
+
+			return $this->dataTransformer->execute($parsedXml);
 		} catch(\Exception $error) {
 			$this->AddError("Error downloading data : $signedUrl : " . $error->getMessage());
-		}
-
-		if ($parsedXml === false) {
 			return false;
 		}
-
-		return $this->dataTransformer->execute($parsedXml);
 	}
 }
 ?>

--- a/src/Transformers/SimpleArrayTransformer.php
+++ b/src/Transformers/SimpleArrayTransformer.php
@@ -8,12 +8,10 @@ class SimpleArrayTransformer implements IDataTransformer {
     public function execute($xmlData) {
 		$items = array();
 		if (empty($xmlData)) {
-			$this->AddError("No XML response found from AWS.");
-			return($items);
+			throw new \Exception("No XML response found from AWS.");
 		}
 
 		if (empty($xmlData->Items)) {
-			$this->AddError("No items found.");
 			return($items);
 		}
 
@@ -21,8 +19,7 @@ class SimpleArrayTransformer implements IDataTransformer {
 			$errorCode = $xmlData->Items->Request->Errors->Error->Code;
 			$errorMessage = $xmlData->Items->Request->Errors->Error->Message;
 			$error = "API ERROR ($errorCode) : $errorMessage";
-			$this->AddError($error);
-			return($items);
+			throw new \Exception($error);
 		}
 
 		// Get each item
@@ -48,7 +45,8 @@ class SimpleArrayTransformer implements IDataTransformer {
 			array_push($items, $item);
 		}
 
-		return($items);    }
+		return($items);
+	}
 }
 
 ?>


### PR DESCRIPTION
`SimpleArrayTransformer` was extracted from original AmazonAPI code. It incorrectly called error handling function that doesn't exist. Now throws errors instead and catches within the AmazonAPI. 

Still needs a rethink for better handling but resolves #14.